### PR TITLE
django-q to django-q2

### DIFF
--- a/coldfront/core/utils/management/commands/add_scheduled_tasks.py
+++ b/coldfront/core/utils/management/commands/add_scheduled_tasks.py
@@ -3,22 +3,23 @@ import datetime
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
-from django_q.models import Schedule
 from django_q.tasks import schedule
 
 base_dir = settings.BASE_DIR
 
 
 class Command(BaseCommand):
-
     def handle(self, *args, **options):
-
         date = timezone.now() + datetime.timedelta(days=1)
         date = date.replace(hour=0, minute=0, second=0, microsecond=0)
-        schedule('coldfront.core.allocation.tasks.update_statuses',
-                 schedule_type=Schedule.DAILY,
-                 next_run=date)
+        schedule(
+            "coldfront.core.allocation.tasks.update_statuses",
+            schedule_type="D",
+            next_run=date,
+        )
 
-        schedule('coldfront.core.allocation.tasks.send_expiry_emails',
-                 schedule_type=Schedule.DAILY,
-                 next_run=date)
+        schedule(
+            "coldfront.core.allocation.tasks.send_expiry_emails",
+            schedule_type="D",
+            next_run=date,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ crispy-bootstrap4==2024.1
 django-environ==0.11.2
 django-model-utils==4.4.0
 django-picklefield==3.1
-django-q==1.3.9
+django-q2==1.7.6
 django-settings-export==1.2.1
 django-simple-history==3.5.0
 django-split-settings==1.3.0


### PR DESCRIPTION
https://django-q2.readthedocs.io/en/master/install.html#migrate-from-django-q-to-django-q2

`django_q2` supports `django@5.0.x` whereas `django_q` does not (and is unmaintained).